### PR TITLE
f5-corregido

### DIFF
--- a/frontend/src/view/Login.jsx
+++ b/frontend/src/view/Login.jsx
@@ -24,13 +24,16 @@ const Login = () => {
     if (result.success) {
       Swal.fire({
         title: `¡Bienvenido!`,
-        text: `Tu rol es: ${ROLES[result.rol] || "Desconocido"}`, // 🔥 Mapear ID a nombre
+        text: `Tu rol es: ${ROLES[result.rol] || "Desconocido"}`, //  Mapear ID a nombre
         icon: "success",
         confirmButtonText: "Continuar",
-        timer: 2000,
+        timer: 1500,
         showConfirmButton: false,
       }).then(() => {
-        navigate("/Galeria");
+        navigate("/Galeria"); 
+        setTimeout(() => {
+          window.location.reload(); // Recarga la página después de la redirección. Se corrige bug de forma simple y no invasiva.
+        }, 100);
       });
     } else {
       Swal.fire({


### PR DESCRIPTION
Antes no se veía el globo del carro a menos que se actualizara la página.
Para no destruir la lógica de todo el código, solo se agrega una línea que recarga la página después del login.
Solución simple pero efectiva.